### PR TITLE
feat(honeycomb): check Artillery version

### DIFF
--- a/lib/honeycomb.js
+++ b/lib/honeycomb.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const Libhoney = require('libhoney');
-const { attachScenarioHooks } = require('./util');
+const { attachScenarioHooks, versionCheck } = require('./util');
 const debug = require('debug')('plugin:publish-metrics:honeycomb');
 
 const { URL } = require('url');
@@ -17,6 +17,10 @@ class HoneycombReporter {
       batchTimeTrigger: 0,
       sampleRate: config.sampleRate || 1
     };
+
+    if (!versionCheck('>=1.7.0')) {
+      console.error(`[publish-metrics][honeycomb] Honeycomb support requires Artillery >= v1.7.0 (current version: ${global.artillery ? global.artillery.version || 'unknown' : 'unknown' })`);
+    }
 
     this.hny = new Libhoney(this.hnyOpts);
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,18 @@
 module.exports = {
-  attachScenarioHooks
+  attachScenarioHooks,
+  versionCheck
 };
+
+const semver = require('semver');
+
+// TODO: Extract into a utility function in Artillery itself
+function versionCheck(range) {
+    if (!global.artillery || !global.artillery.version) {
+      return  false;
+    } else {
+      return semver.satisfies(global.artillery.version, range);
+    }
+}
 
 function attachScenarioHooks(script, specs) {
   const scenarios = script.scenarios;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "debug": "^4.1.1",
     "dogapi": "^2.8.3",
     "hot-shots": "^6.0.1",
-    "libhoney": "^2.2.1"
+    "libhoney": "^2.2.1",
+    "semver": "^7.3.5"
   },
   "devDependencies": {
     "artillery": "^1.6.0-26",


### PR DESCRIPTION
Honeycomb support depends on APIs available in >= 1.7.0 only.