### PR TITLE
Enable SSL + Certificate Authority self-signed

### DIFF
--- a/lib/prometheus.js
+++ b/lib/prometheus.js
@@ -1,4 +1,6 @@
 const http = require('http');
+const https = require('https');
+const fs = require('fs');
 const PromClient = require('prom-client');
 const uuid = require('uuid');
 const debug = require('debug')('plugin:publish-metrics:prometheus');
@@ -18,6 +20,7 @@ class PrometheusReporter {
 
     this.prometheusOpts = {
       pushgatewayUrl: config.pushgateway,
+      ca: config.ca,
     };
 
     debug('ensuring pushgatewayUrl is configured');
@@ -31,9 +34,11 @@ class PrometheusReporter {
     this.registerMetrics(this.config.prefix)
 
     debug('creating pushgateway client using url: %s', this.prometheusOpts.pushgatewayUrl);
+    const httpModule = isHttps(this.prometheusOpts.pushgatewayUrl) ? https : http;
     this.pushgateway = new PromClient.Pushgateway(this.prometheusOpts.pushgatewayUrl,{
       timeout: 5000, //Set the request timeout to 5000ms
-      agent: new http.Agent({
+      ca: this.prometheusOpts.ca ? fs.readFileSync(this.prometheusOpts.ca) : null,
+      agent: new httpModule.Agent({
         keepAlive: true,
         keepAliveMsec: 10000,
         maxSockets: 10,
@@ -135,6 +140,10 @@ class PrometheusReporter {
 
 function createPrometheusReporter(config, events, script) {
   return new PrometheusReporter(config, events, script);
+}
+
+function isHttps(href) {
+  return href.search(/^https/) !== -1;
 }
 
 module.exports = {


### PR DESCRIPTION
Hi!
First, thank you for your job.

I'm trying to use Artillery and send report to prometheus with [pushgateway](https://prometheus.io/docs/practices/pushing/).
I have local instance with SSL enabled (https://pushgateway.prometheus.local)

When I run my tests, I got an error : 
```
Error: Protocol "https:" not supported. Expected "http:"
``` 

This error is caused by `http.Agent` instead of `https.Agent`
https://github.com/artilleryio/artillery-plugin-publish-metrics/blob/master/lib/prometheus.js#L36

Then, when I change that, I have second error
```
Error: self signed certificate
```
Because, in my local environment I use self signed certificate.

This is my purposes : 
- Check url for switch Agent between http & https
- Add possibility to load Certificate Authority (CA) and so validate request.

Example of Artillery configuration with TLS : 
```yaml
config:
  target: http://api.local.dev

  plugins:
    publish-metrics:
      - type: prometheus
        pushgateway: "https://pushgateway.prometheus.local"
        ca: '/path/to/ca.crt'
        tags:
          - "testId:mytest123"

scenarios:
  - ...
```

Feel free to edit my work.