### PR TITLE
fix: set default for included options

### DIFF
--- a/lib/cloudwatch.js
+++ b/lib/cloudwatch.js
@@ -39,7 +39,14 @@ class CloudWatchReporter {
       dimensions: config.dimensions || [],
       extended: config.extended || false,
       excluded: config.excluded || [],
-      included: config.included || []
+      included: config.included || [
+        'http.response_time.min',
+        'http.response_time.max',
+        'http.response_time.median',
+        'vusers.created',
+        'vusers.failed',
+        'vusers.completed'
+      ]
     };
 
     this.pendingRequests = 0;


### PR DESCRIPTION
@hassy confusion about the default included[] defaults, it wasn't set in the code yet, just the options

now it will use the default list as explained in #30 and it can be set to an empty list to disable it (or a different list)

```yaml

config:
  plugins:
    publish-metrics:
      - type: cloudwatch
        region: "us-west-2"
        namespace: "artillery" # optional (default to "artillery")
        # Used as the Name dimensions value
        name: "web service" # optional (default to "loadtest")
        # include only specified metrics
        included: #optional (default includes the following metrics, can be set to an empty list to disable)
          - "http.response_time.min"
          - "http.response_time.max"
          - "http.response_time.median"
          - "vusers.created"
          - "vusers.failed"
          - "vusers.completed"
        # Default only includes the following stats from the summaries metrics:
        # ['p99', 'max', 'min', 'median', 'count'],
        # if set to true, all stats are sent to cw.
        extended: true # optional (default to false)
        # exclude specific metrics
        excluded: #optional (default empty)
          - "http.codes.200"
          - "vusers.session_length.min"
          - "vusers.session_length.max"
          - "vusers.session_length.p99"
          - "vusers.session_length.median"
          - "vusers.session_length.count"
          - "http.responses"
          - "http.requests"
          - "http.response_time.count"
        # additional dimensions
        dimensions: # optional (default empty)
          - name: "scenario"
            value: "product pages"
          - name: ".."
            value: ".."
```