### PR TITLE
cloudwatch: rename to includeOnly and set default empty

### DIFF
--- a/lib/cloudwatch.js
+++ b/lib/cloudwatch.js
@@ -39,7 +39,7 @@ class CloudWatchReporter {
       dimensions: config.dimensions || [],
       extended: config.extended || false,
       excluded: config.excluded || [],
-      included: config.included || []
+      includeOnly: config.includeOnly || []
     };
 
     this.pendingRequests = 0;
@@ -102,7 +102,7 @@ class CloudWatchReporter {
       return;
     }
 
-    if (this.options.included.length > 0 && !this.options.included.includes(name)) {
+    if (this.options.includeOnly.length > 0 && !this.options.includeOnly.includes(name)) {
       return;
     }
 


### PR DESCRIPTION
updated the options to

```yaml

# Notes about cloudwatch custom metrics billing

# The default options send all data reported by artillery.
# This will create a fairly large number of custom metrics in cloudwatch that can't be deleted.
# you might want to start testing with a whitelist of metrics using the `includeOnly` options.

config:
  plugins:
    publish-metrics:

      - type: cloudwatch
        region: "us-west-2"
        namespace: "artillery" # optional (default to "artillery")
        # Used as the Name dimensions value
        name: "web service" # optional (default to "loadtest")
        # Default only includes the following stats from the summaries metrics:
        # ['p99', 'max', 'min', 'median', 'count'],
        # if set to true, all stats are sent to cw.
        extended: true # optional (default to false)
        # exclude specific metrics
        excluded: #optional (default empty)
          - "http.codes.200"
          - "vusers.session_length.min"
          - "vusers.session_length.max"
          - "vusers.session_length.p99"
          - "vusers.session_length.median"
          - "..."
        # include only specified metrics
        includeOnly: #optional (default empty)
          - "http.response_time.min"
          - "http.response_time.max"
          - "..."
        # additional dimensions
        dimensions: # optional (default empty)
          - name: "scenario"
            value: "product pages"
          - name: ".."
            value: ".."
```

@hassy  